### PR TITLE
Add a URL param for era

### DIFF
--- a/components/Menu.vue
+++ b/components/Menu.vue
@@ -10,7 +10,7 @@
   >
     <v-btn
       value="index"
-      @click="$router.push({ path: '/' })"
+      @click="getRouteAction('/')"
     >
       <v-icon left>
         mdi-home
@@ -19,7 +19,7 @@
     </v-btn>
     <v-btn
       value="contact"
-      @click="$router.push({ path: '/contact' })"
+      @click="getRouteAction('/contact')"
     >
       <v-icon left>
         mdi-card-account-mail
@@ -38,7 +38,7 @@
       <v-list-item
         link
         value="index"
-        @click="$router.push({ path: '/' })"
+        @click="getRouteAction('/')"
       >
         <v-list-item-icon>
           <v-icon>mdi-home</v-icon>
@@ -50,7 +50,7 @@
       <v-list-item
         link
         value="contact"
-        @click="$router.push({ path: '/contact' })"
+        @click="getRouteAction('/contact')"
       >
         <v-list-item-icon>
           <v-icon>mdi-card-account-mail</v-icon>
@@ -64,6 +64,8 @@
 </template>
 
 <script>
+import { mapGetters } from 'vuex'
+
 export default {
   name: 'Menu',
   props: {
@@ -76,6 +78,9 @@ export default {
     menu: 'index'
   }),
   computed: {
+    ...mapGetters([
+      'getCurrentSiteEraForPath'
+    ]),
     currentRoute () {
       return this.$nuxt.$route.name
     }
@@ -87,6 +92,16 @@ export default {
   },
   mounted () {
     this.menu = this.currentRoute
+  },
+  methods: {
+    getRouteAction (target) {
+      return this.$router.push(
+        {
+          path: target,
+          query: { era: this.getCurrentSiteEraForPath }
+        }
+      )
+    }
   }
 }
 </script>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -21,7 +21,7 @@
         </v-list-item>
         <v-list-item
           link
-          @click="$router.push({ path: '/' })"
+          @click="$router.push({ path: '/', query: { era: $route.query.era } })"
         >
           <v-list-item-content>
             <v-list-item-title class="text-h6">
@@ -47,7 +47,7 @@
       <v-avatar
         size="36px"
         class="mr-5"
-        @click="$router.push({ path: '/' })"
+        @click="$router.push({ path: '/', query: { era: $route.query.era } })"
       >
         <img
           alt="Moriel Schottlender"
@@ -56,7 +56,7 @@
       </v-avatar>
       <v-toolbar-title
         v-if="$vuetify.breakpoint.smAndUp"
-        @click="$router.push({ path: '/' })"
+        @click="$router.push({ path: '/', query: { era: $route.query.era } })"
         v-text="title"
       />
 
@@ -120,6 +120,7 @@
 </template>
 
 <script>
+import { mapGetters } from 'vuex'
 import Menu from '~/components/Menu.vue'
 import Footer from '~/components/Footer.vue'
 
@@ -147,6 +148,11 @@ export default {
     }
   },
   computed: {
+    ...mapGetters([
+      'getSiteEraFromIndex',
+      'getCurrentSiteEra',
+      'getCurrentSiteEraForPath'
+    ]),
     siteEraClass () {
       return [
         'style-' + this.$store.getters.getCurrentSiteEra,
@@ -174,7 +180,35 @@ export default {
       }
     }
   },
+  watch: {
+    siteEra (value) {
+      this.setRouteForEra()
+    }
+  },
+  mounted () {
+    const era = this.$route.query.era || 'today'
+    console.log('mounted', {
+      'this.$route.query.era': this.$route.query.era,
+      era
+    })
+
+    this.$store.commit('changeSiteEraFromLabel', era)
+    this.setRouteForEra()
+  },
   methods: {
+    setRouteForEra () {
+      const path = this.$route.name === 'index'
+        ? '/'
+        : `/${this.$route.name}`
+
+      // Update the url param
+      this.$router.push(
+        {
+          path,
+          query: { era: this.getCurrentSiteEraForPath }
+        }
+      )
+    },
     decreaseEra () {
       this.$store.commit('decreaseSiteEra')
     },

--- a/store/index.js
+++ b/store/index.js
@@ -176,6 +176,22 @@ export const mutations = {
   changeSiteStyle (state, style) {
     state.siteEra = style
   },
+  changeSiteEraFromLabel (state, label) {
+    if (label === 'future') {
+      label = 2100
+    } else if (label === 'today') {
+      label = 2021
+    }
+    let index = state.siteEraLabels.indexOf(Number(label))
+
+    if (index < 0) {
+      // default on today
+      index = eras.length - 2
+    } else {
+      // set to requested index
+      state.siteEra = index
+    }
+  },
   setToTodayEra (state) {
     state.siteEra = eras.length - 2
   },
@@ -199,7 +215,17 @@ export const mutations = {
 export const getters = {
   getSiteEraFromIndex: state => (index) => {
     return state.siteEraLabels[index] ||
-      state.siteEraLabels[state.siteEraLabels.length - 1]
+      state.siteEraLabels[state.siteEraLabels.length - 2]
+  },
+  getCurrentSiteEraForPath: (state) => {
+    const current = state.siteEraLabels[state.siteEra]
+
+    if (current === 2021) {
+      return 'today'
+    } else if (current === 2100) {
+      return 'future'
+    }
+    return current
   },
   getCurrentSiteEra: (state) => {
     return state.siteEraLabels[state.siteEra]


### PR DESCRIPTION
Make sure era parameter is always in the URL so we can allow
viewers to share a specific era, but also move between pages
with the same era (especially when the form sends info to
thanks page)